### PR TITLE
Rework CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,23 @@
 language: elixir
 # Needed for Cassandra
 sudo: required
+dist: bionic
 services:
-  - cassandra
-  - rabbitmq
+  - docker
 env:
-  - CASSANDRA_DB_HOST=localhost RABBITMQ_HOST=localhost MIX_ENV=test
+  global:
+    - CASSANDRA_DB_HOST=localhost RABBITMQ_HOST=localhost MIX_ENV=test
+  jobs:
+    - RABBITMQ_VERSION=3.7.15 CASSANDRA_VERSION=3.11.3
 matrix:
   include:
     - elixir: 1.6.5
       otp_release: 20.3
+before_install:
+  - docker pull rabbitmq:$RABBITMQ_VERSION
+  - docker run -d -p 127.0.0.1:5672:5672 -p 127.0.0.1:15672:15672 rabbitmq:$RABBITMQ_VERSION
+  - docker pull cassandra:$CASSANDRA_VERSION
+  - docker run -d -p 127.0.0.1:9042:9042 cassandra:$CASSANDRA_VERSION
 before_script:
   # Needed or Elixir 1.6 will fail due to a non-updated index
   - ~/.mix/rebar3 update


### PR DESCRIPTION
This PR uses a brand new approach to dependencies, which allows to set a well-known matrix based on different docker containers. It also fixes CI with new Travis workers.